### PR TITLE
ci: use npm trusted publishing (OIDC) instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      # Required for npm trusted publishing (OIDC) and provenance
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -23,13 +24,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org/
           cache: npm
+      # Trusted publishing (OIDC) requires npm >= 11.5.1
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run lint
       - run: npm test
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Contexte

Le job Release échouait avec `EINVALIDNPMTOKEN` : un `NPM_TOKEN` (invalide/vide) était encore configuré, ce qui forçait le chemin d'authentification par token au lieu de l'OIDC.

Maintenant que le **trusted publishing OIDC** est configuré côté package npm, on laisse `@semantic-release/npm` réaliser l'échange de token OIDC lui-même (`getIDToken("npm:registry.npmjs.org")` → échange avec le registry → skip de la vérif de token).

## Changements (`release.yaml`)

- **Suppression de `NPM_TOKEN`** → le chemin OIDC est emprunté
- **Suppression de `registry-url`** dans `setup-node` : il écrivait un `.npmrc` avec un `_authToken` vide qui cassait l'authentification
- **Suppression de `NPM_CONFIG_PROVENANCE`** : le trusted publishing génère la provenance automatiquement
- **Mise à jour de npm en dernière version** : le trusted publishing exige npm >= 11.5.1

`id-token: write` et `GITHUB_TOKEN` (pour la release GitHub) sont conservés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)